### PR TITLE
Remove createJSModules @ovveride marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/io/callstack/react/opentok/MainPackage.java
+++ b/android/src/main/java/io/callstack/react/opentok/MainPackage.java
@@ -17,7 +17,8 @@ public class MainPackage implements ReactPackage {
             new OpenTokSessionManager(reactContext)
         );
     }
-
+    
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/io/callstack/react/opentok/MainPackage.java
+++ b/android/src/main/java/io/callstack/react/opentok/MainPackage.java
@@ -17,7 +17,7 @@ public class MainPackage implements ReactPackage {
             new OpenTokSessionManager(reactContext)
         );
     }
-    
+
     // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();

--- a/android/src/main/java/io/callstack/react/opentok/MainPackage.java
+++ b/android/src/main/java/io/callstack/react/opentok/MainPackage.java
@@ -18,7 +18,7 @@ public class MainPackage implements ReactPackage {
         );
     }
 
-    // Depreciated RN 0.47
+    // Deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/io/callstack/react/opentok/MainPackage.java
+++ b/android/src/main/java/io/callstack/react/opentok/MainPackage.java
@@ -18,7 +18,6 @@ public class MainPackage implements ReactPackage {
         );
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/io/callstack/react/opentok/MainPackage.java
+++ b/android/src/main/java/io/callstack/react/opentok/MainPackage.java
@@ -18,7 +18,7 @@ public class MainPackage implements ReactPackage {
         );
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. This PR removes the @ovveride marker. This is backwards compatible.